### PR TITLE
참여관리 및 채팅부분 수정

### DIFF
--- a/src/api/chat-api.tsx
+++ b/src/api/chat-api.tsx
@@ -14,7 +14,7 @@ export default class ChatApi {
   // 메세지 보내기
   static async sendChatMessages({ message, roomId }: ChatSendRequest) {
     const response = await Instance.post(
-      `/chat-service/api/chatrooms/${roomId}/message`,
+      `/chat-service/api/chats/${roomId}/message`,
       message,
     );
     if (response) {
@@ -39,7 +39,7 @@ export default class ChatApi {
   // 채팅방 디테일 멤버 정보랑 채팅내역 가져오기
   static async getChatRoomData(chatRoomId: string) {
     const response = await Instance.get(
-      `/chat-service/api/chatrooms/${chatRoomId}`,
+      `/chat-service/api/chats/${chatRoomId}`,
     );
     if (response) {
       const temp = response.data as ChatRoomResponse;
@@ -92,7 +92,6 @@ export default class ChatApi {
         headers: {
           Authorization: localStorage.getItem("accessToken"),
           "Content-Type": "application/json",
-          // "X-Requested-With": "XMLHttpRequest",
         },
         withCredentials: true,
       },

--- a/src/api/chat-api.tsx
+++ b/src/api/chat-api.tsx
@@ -37,9 +37,13 @@ export default class ChatApi {
   }
 
   // 채팅방 디테일 멤버 정보랑 채팅내역 가져오기
-  static async getChatRoomData(chatRoomId: string) {
+  static async getChatRoomData(data: {
+    chatRoomId: string;
+    page: number;
+    size: number;
+  }) {
     const response = await Instance.get(
-      `/chat-service/api/chats/${chatRoomId}`,
+      `/chat-service/api/chats/${data.chatRoomId}?pagingIndex=${data.page}&pagingSize=${data.size}`,
     );
     if (response) {
       const temp = response.data as ChatRoomResponse;

--- a/src/api/types/apply-type.ts
+++ b/src/api/types/apply-type.ts
@@ -7,6 +7,7 @@ export type ApplyType = {
     address: string;
     gender: string;
     ageRange: number;
+    dealCount: number;
   };
   createdTime: string;
   status:

--- a/src/api/types/profile-type.ts
+++ b/src/api/types/profile-type.ts
@@ -10,6 +10,7 @@ export type ProfileData = {
   accountNumber: string;
   profileImage: string;
   blocked: boolean;
+  dealCount: number;
 };
 
 export type ProfileGetResponse = FinalResponse<ProfileData>;

--- a/src/components/apply/applicant-item.tsx
+++ b/src/components/apply/applicant-item.tsx
@@ -37,7 +37,7 @@ export const ApplicantItem = (props: ApplicantItemDetailProps) => {
         />
       </ApplicantImage>
       {props.isDeletedUser && (
-        <ApplicantInfo>
+        <ApplicantInfo style={{ justifyContent: "center" }}>
           <ApplicantDeletedUserDiv>알 수 없음</ApplicantDeletedUserDiv>
         </ApplicantInfo>
       )}
@@ -46,9 +46,10 @@ export const ApplicantItem = (props: ApplicantItemDetailProps) => {
           <ApplicantLocation>{props.applicantInfo.address}</ApplicantLocation>
           <ApplicantNickname>{props.applicantInfo.nickName}</ApplicantNickname>
           <ApplicantMoreInfo>
-            도움횟수 16 <Bullet />{" "}
-            {props.applicantInfo.gender === "male" ? "남" : "여"} <Bullet />{" "}
-            {props.applicantInfo.ageRange * 10}대
+            {/* 도움횟수 16 <Bullet />{" "} */}
+            {props.applicantInfo.gender === "male"
+              ? "남"
+              : "여"} <Bullet /> {props.applicantInfo.ageRange * 10}대
           </ApplicantMoreInfo>
         </ApplicantInfo>
       )}
@@ -69,16 +70,17 @@ const ApplicantItemWrapper = styled.div`
   padding: 20px 25px;
   gap: 10px;
   border-top: 1px solid #e4e8f1;
+  align-items: center;
 `;
 
 const ApplicantImage = styled.div`
   height: 100%;
   display: flex;
   position: relative;
-  flex: 1.2;
-  align-items: start;
+  align-items: center;
   & img {
-    width: 100%;
+    width: 3.944rem;
+    height: 3.944rem;
     aspect-ratio: 1/1;
     border-radius: 10px;
   }
@@ -90,6 +92,8 @@ const ApplicantInfo = styled.div`
   flex-direction: column;
   justify-content: space-between;
   padding-bottom: 2px;
+  height: 80%;
+  /* height: 100%; */
 `;
 
 const ApplicantLocation = styled.div`

--- a/src/components/apply/applicant-item.tsx
+++ b/src/components/apply/applicant-item.tsx
@@ -46,10 +46,9 @@ export const ApplicantItem = (props: ApplicantItemDetailProps) => {
           <ApplicantLocation>{props.applicantInfo.address}</ApplicantLocation>
           <ApplicantNickname>{props.applicantInfo.nickName}</ApplicantNickname>
           <ApplicantMoreInfo>
-            {/* 도움횟수 16 <Bullet />{" "} */}
-            {props.applicantInfo.gender === "male"
-              ? "남"
-              : "여"} <Bullet /> {props.applicantInfo.ageRange * 10}대
+            도움횟수 {props.applicantInfo.dealCount} <Bullet />{" "}
+            {props.applicantInfo.gender === "male" ? "남" : "여"} <Bullet />{" "}
+            {props.applicantInfo.ageRange * 10}대
           </ApplicantMoreInfo>
         </ApplicantInfo>
       )}

--- a/src/components/chat/chat-app-bar.tsx
+++ b/src/components/chat/chat-app-bar.tsx
@@ -42,7 +42,10 @@ export const ChatAppBar = ({
       <AppBar.AppBarNavigate style={{ padding: "4% 21px" }}>
         <AppBar.BackButton
           isColorMode={isColorMode}
-          onClick={() => navigate("/chat", { replace: true })}
+          onCustomClick={() => {
+            navigate("/chat", { replace: true });
+          }}
+          isBack={false}
         />
         <AppBar.HeaderText>{lastTransfer.title}</AppBar.HeaderText>
         {myId === creatorId ? (

--- a/src/components/chat/chat-item.tsx
+++ b/src/components/chat/chat-item.tsx
@@ -27,34 +27,37 @@ export const ChatItem = ({
       {userId === myId && (
         <DateDiv>{date ? ChatdateToMsgtype(date) : ""}</DateDiv>
       )}
-      {userId !== myId && (
-        <ProfileImg
-          onClick={() => {
-            if (userId !== -2) {
-              setProfileUserId(Number(userId));
-              setProfileModal(true);
-            } else {
-              setDeletedProfileModal(true);
-            }
-          }}
-          src={imgurl}
-        ></ProfileImg>
-      )}
-      <ChatColumnBox
-        style={{
-          alignItems: userId === myId ? "flex-end" : "flex-start",
-        }}
-      >
-        {userId !== myId && <NameDiv>{userName}</NameDiv>}
-        <ChatBox
+      <RowBox>
+        {userId !== myId && (
+          <ProfileImg
+            onClick={() => {
+              if (userId !== -2) {
+                setProfileUserId(Number(userId));
+                setProfileModal(true);
+              } else {
+                setDeletedProfileModal(true);
+              }
+            }}
+            src={imgurl}
+          ></ProfileImg>
+        )}
+        <ChatColumnBox
           style={{
-            backgroundColor:
-              userId === myId ? colorTheme.blue100 : colorTheme.blue300,
+            alignItems: userId === myId ? "flex-end" : "flex-start",
+            marginRight: userId === myId ? "1.28rem" : "0rem",
           }}
         >
-          <ChatText>{children}</ChatText>
-        </ChatBox>
-      </ChatColumnBox>
+          {userId !== myId && <NameDiv>{userName}</NameDiv>}
+          <ChatBox
+            style={{
+              backgroundColor:
+                userId === myId ? colorTheme.blue100 : colorTheme.blue300,
+            }}
+          >
+            <ChatText>{children}</ChatText>
+          </ChatBox>
+        </ChatColumnBox>
+      </RowBox>
       {userId !== myId && (
         <DateDiv>{date ? ChatdateToMsgtype(date) : ""}</DateDiv>
       )}
@@ -75,7 +78,7 @@ const Container = styled.div`
 const ProfileImg = styled.img`
   width: 2.22rem;
   height: 2.22rem;
-  margin: 0.6rem 4% 0 7.15%;
+  margin: 0.6rem 1rem 0 1.78rem;
   border-radius: 0.83rem;
   background-color: #d9d9d9;
 `;
@@ -85,7 +88,6 @@ const ChatBox = styled.div`
   height: auto;
   width: auto;
   padding: 0.5rem 0.61rem;
-  margin-right: 1.28rem;
   border-radius: 0.28rem;
 `;
 
@@ -98,7 +100,7 @@ const ChatText = styled.div`
 const ChatColumnBox = styled.div`
   display: flex;
   flex-direction: column;
-  max-width: 62.1%;
+  max-width: 12.9rem;
   gap: 0.4rem;
 `;
 
@@ -110,4 +112,10 @@ const NameDiv = styled.div`
 const DateDiv = styled.div`
   font-size: 0.56rem;
   color: #707379;
+`;
+
+const RowBox = styled.div`
+  display: flex;
+  direction: row;
+  align-items: flex-start;
 `;

--- a/src/components/chat/chat-item.tsx
+++ b/src/components/chat/chat-item.tsx
@@ -3,6 +3,7 @@ import { styled } from "styled-components";
 import { ChatItemType } from "./type";
 
 import { colorTheme } from "@/style/color-theme";
+import { ChatdateToMsgtype } from "@/utils/chatdate-to-msgtype";
 
 export const ChatItem = ({
   children,
@@ -12,6 +13,7 @@ export const ChatItem = ({
   setProfileModal,
   setProfileUserId,
   setDeletedProfileModal,
+  date,
 }: ChatItemType) => {
   const tempId = localStorage.getItem("userId");
   const myId = tempId ? Number(tempId) : -1;
@@ -22,6 +24,9 @@ export const ChatItem = ({
         justifyContent: userId === myId ? "flex-end" : "flex-start",
       }}
     >
+      {userId === myId && (
+        <DateDiv>{date ? ChatdateToMsgtype(date) : ""}</DateDiv>
+      )}
       {userId !== myId && (
         <ProfileImg
           onClick={() => {
@@ -50,6 +55,9 @@ export const ChatItem = ({
           <ChatText>{children}</ChatText>
         </ChatBox>
       </ChatColumnBox>
+      {userId !== myId && (
+        <DateDiv>{date ? ChatdateToMsgtype(date) : ""}</DateDiv>
+      )}
     </Container>
   );
 };
@@ -60,6 +68,8 @@ const Container = styled.div`
   height: auto;
   display: flex;
   flex-direction: row;
+  align-items: flex-end;
+  gap: 0.5rem;
 `;
 
 const ProfileImg = styled.img`
@@ -74,25 +84,30 @@ const ChatBox = styled.div`
   max-width: 100%;
   height: auto;
   width: auto;
-  padding: 3.6% 4.7%;
-  margin-right: 6%;
+  padding: 0.5rem 0.61rem;
+  margin-right: 1.28rem;
   border-radius: 0.28rem;
 `;
 
 const ChatText = styled.div`
   color: black;
   font-size: 1.2rem;
-  word-break: break-all;
+  white-space: pre-wrap;
 `;
 
 const ChatColumnBox = styled.div`
   display: flex;
   flex-direction: column;
-  width: 62.1%;
+  max-width: 62.1%;
   gap: 0.4rem;
 `;
 
 const NameDiv = styled.div`
   font-size: 0.83rem;
+  color: #707379;
+`;
+
+const DateDiv = styled.div`
+  font-size: 0.56rem;
   color: #707379;
 `;

--- a/src/components/chat/chat-list-item.tsx
+++ b/src/components/chat/chat-list-item.tsx
@@ -52,7 +52,7 @@ export const ChatListItem = (props: ChatRoomItemType) => {
                 : ""}
           </TitleText>
           <ItemText style={{ color: "#828282" }}>
-            <IconImg />
+            {/* <IconImg /> */}
             {" " + props.creatorNickname + "   "} <IconImg src={dateSVG} />
             {" " + BackdateToItemtype(props.startDate) + "   "}
             <IconImg src={locationSVG} />
@@ -115,7 +115,7 @@ const LeftColumnDiv = styled.div`
   display: flex;
   height: 2.7rem;
   flex-direction: column;
-  justify-content: flex-start;
+  justify-content: center;
   padding: 0 0 0 4.61%;
   gap: 0.33rem;
 `;

--- a/src/components/chat/type.ts
+++ b/src/components/chat/type.ts
@@ -12,6 +12,7 @@ export type ChatItemType = {
   setProfileModal: React.Dispatch<React.SetStateAction<boolean>>;
   setProfileUserId: React.Dispatch<React.SetStateAction<number>>;
   setDeletedProfileModal: React.Dispatch<React.SetStateAction<boolean>>;
+  date?: string;
 };
 
 export type InputType = {

--- a/src/components/common/app-bar.tsx
+++ b/src/components/common/app-bar.tsx
@@ -33,13 +33,18 @@ const AppBarNavigate = (props: AppBarProps) => {
   return <NavigateWrapper {...props}>{props.children}</NavigateWrapper>;
 };
 
-const BackButton = ({ isColorMode = false, ...props }: AppBarProps) => {
-  const { onClick, ...restProps } = props;
+const BackButton = ({
+  isColorMode = false,
+  isBack = true,
+  ...props
+}: AppBarProps) => {
+  const { onClick, onCustomClick, ...restProps } = props;
   const navigate = useNavigate();
 
   const handleClick = () => {
-    navigate(-1);
+    if (isBack) navigate(-1);
     if (onClick) onClick;
+    if (onCustomClick) onCustomClick();
   };
   return (
     <StyledButton onClick={handleClick} {...restProps}>

--- a/src/components/common/type.ts
+++ b/src/components/common/type.ts
@@ -50,6 +50,8 @@ export type AppBarProps = {
   isBorderExist?: boolean;
   isBigSizeText?: boolean;
   children?: React.ReactNode;
+  isBack?: boolean;
+  onCustomClick?: () => void;
 } & Omit<React.HTMLAttributes<HTMLElement>, "type">;
 
 export type RightButtonProps = {

--- a/src/components/layout/profile-layout.tsx
+++ b/src/components/layout/profile-layout.tsx
@@ -17,6 +17,7 @@ export const ProfileLayout = ({ children }: { children: ReactNode }) => {
     accountNumber: "",
     profileImage: "",
     blocked: false,
+    dealCount: 0,
   });
 
   const navigate = useNavigate();

--- a/src/components/mypage/mypage-list-profile.tsx
+++ b/src/components/mypage/mypage-list-profile.tsx
@@ -8,9 +8,9 @@ import FemaleSVG from "@/assets/icons/female.svg";
 import KnotWhiteBackSVG from "@/assets/icons/knot-white-back.svg";
 import LocationWhiteBackSVG from "@/assets/icons/location-white-back.svg";
 import MaleSVG from "@/assets/icons/male.svg";
+import PersonSVG from "@/assets/icons/person-white-back.svg";
 import { DropDownMenu } from "@/components/common/drop-down-menu";
 import { Modal } from "@/components/common/modal";
-// import PersonSVG from "@/assets/icons/person-white-back.svg";
 import { useGetBankData } from "@/hooks/queries/useGetBankData";
 import { useGetProfile } from "@/hooks/queries/useGetProfile";
 import { useSignOut } from "@/hooks/queries/useSignOut";
@@ -84,9 +84,10 @@ export const MypageListProfile = () => {
               <OtherStateIcon src={LocationWhiteBackSVG} />
               <div>{myProfile?.address}</div>
             </PriceStateBox>
-            {/* <PriceStateBox style={{ width: "5rem" }}>
+            <PriceStateBox style={{ width: "5rem" }}>
               <OtherStateIcon src={PersonSVG} />
-            </PriceStateBox> */}
+              <div>도움횟수 {myProfile?.dealCount}</div>
+            </PriceStateBox>
           </OtherStateColumnBox>
         </StateOrangeBox>
       </ColumnBox>

--- a/src/components/posting/posting-app-bar.tsx
+++ b/src/components/posting/posting-app-bar.tsx
@@ -10,7 +10,7 @@ export const PostingAppBar = (props: PostingAppBarProps) => {
   return (
     <AppBar isBorderExist={true}>
       <AppBar.AppBarNavigate>
-        <AppBar.BackButton onClick={props.onClick} />
+        <AppBar.BackButton onCustomClick={props.onCustomClick} />
         <AppBar.HeaderText>{props.nowPage}/7</AppBar.HeaderText>
         <div style={{ width: "30px" }} />
       </AppBar.AppBarNavigate>

--- a/src/components/posting/type.ts
+++ b/src/components/posting/type.ts
@@ -13,6 +13,7 @@ export type DatePickerProps = {
 
 export type PostingAppBarProps = {
   nowPage: number;
+  onCustomClick: () => void;
 } & Omit<React.HTMLAttributes<HTMLElement>, "type">;
 
 export type TextAreaType = {

--- a/src/hooks/chat/useChatDataSetting.tsx
+++ b/src/hooks/chat/useChatDataSetting.tsx
@@ -14,8 +14,6 @@ export const useChatDataSetting = (props: ChatMakeRoom) => {
   const { data: roomData } = useGetChatRoomData(props.roomId);
   const { data: bankData } = useGetBankData();
 
-  console.log("roomData: ", roomData?.pages[0]);
-
   useEffect(() => {
     const myId = localStorage.getItem("userId") || "0";
     const users: ChatRoomMember[] =
@@ -29,7 +27,6 @@ export const useChatDataSetting = (props: ChatMakeRoom) => {
     const availableBudget: number = bankData ? bankData.availableBudget : -1;
     const title: string = roomData ? roomData.pages[0].postInfo.title : "";
 
-    console.log("availableBudget!!!: ", availableBudget);
     setTransfer({
       users: users,
       price: price,

--- a/src/hooks/chat/useChatDataSetting.tsx
+++ b/src/hooks/chat/useChatDataSetting.tsx
@@ -14,18 +14,20 @@ export const useChatDataSetting = (props: ChatMakeRoom) => {
   const { data: roomData } = useGetChatRoomData(props.roomId);
   const { data: bankData } = useGetBankData();
 
-  console.log("roomData: ", roomData);
+  console.log("roomData: ", roomData?.pages[0]);
 
   useEffect(() => {
     const myId = localStorage.getItem("userId") || "0";
     const users: ChatRoomMember[] =
-      roomData?.userInfos?.filter((item) => item.userId !== Number(myId)) || [];
-    const price: number = roomData ? roomData.postInfo.pay : -1;
+      roomData?.pages[0].userInfos?.filter(
+        (item) => item.userId !== Number(myId),
+      ) || [];
+    const price: number = roomData ? roomData.pages[0].postInfo.pay : -1;
     const status: boolean =
-      roomData?.postInfo.status === "TRANSACTION_COMPLETED";
-    const dealId: number = roomData ? roomData.postInfo.dealId : -1;
+      roomData?.pages[0].postInfo.status === "TRANSACTION_COMPLETED";
+    const dealId: number = roomData ? roomData.pages[0].postInfo.dealId : -1;
     const availableBudget: number = bankData ? bankData.availableBudget : -1;
-    const title: string = roomData ? roomData.postInfo.title : "";
+    const title: string = roomData ? roomData.pages[0].postInfo.title : "";
 
     console.log("availableBudget!!!: ", availableBudget);
     setTransfer({
@@ -51,5 +53,5 @@ export const useChatDataSetting = (props: ChatMakeRoom) => {
     });
   }, [roomData, bankData]);
 
-  return roomData?.messages;
+  // return roomData?.pages[0].messages;
 };

--- a/src/hooks/queries/useGetChatRoomData.tsx
+++ b/src/hooks/queries/useGetChatRoomData.tsx
@@ -1,10 +1,22 @@
-import { useQuery } from "@tanstack/react-query";
+import { useInfiniteQuery } from "@tanstack/react-query";
 
 import ChatApi from "@/api/chat-api";
 
 export const useGetChatRoomData = (roomId: string) => {
-  return useQuery({
+  return useInfiniteQuery({
     queryKey: ["chat-room", roomId],
-    queryFn: () => ChatApi.getChatRoomData(roomId),
+    queryFn: ({ pageParam }) => {
+      let size = 20;
+      if (pageParam === 0 || pageParam === 1) size = 10;
+      return ChatApi.getChatRoomData({
+        chatRoomId: roomId,
+        page: pageParam,
+        size: size,
+      });
+    },
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, allPages) => {
+      return lastPage.messages.length !== 0 ? allPages.length : undefined;
+    },
   });
 };

--- a/src/hooks/queries/useGetProfile.tsx
+++ b/src/hooks/queries/useGetProfile.tsx
@@ -4,7 +4,6 @@ import ProfileApi from "@/api/profile-api";
 
 export const useGetProfile = (userId?: number) => {
   if (userId) {
-    console.log("Other Profile");
     return useQuery({
       queryKey: ["userProfile", userId],
       queryFn: () => ProfileApi.getProfile(userId),

--- a/src/pages/post/applicant-list-page.tsx
+++ b/src/pages/post/applicant-list-page.tsx
@@ -4,7 +4,6 @@ import { styled } from "styled-components";
 import { ApplicantList } from "./applicant-list";
 
 import { AppBar } from "@/components/common/app-bar";
-import { DefaultLayout } from "@/components/layout/default-layout";
 
 export const ApplicantListPage = () => {
   const { postId } = useParams();

--- a/src/pages/post/applicant-list-page.tsx
+++ b/src/pages/post/applicant-list-page.tsx
@@ -1,4 +1,5 @@
 import { useParams } from "react-router-dom";
+import { styled } from "styled-components";
 
 import { ApplicantList } from "./applicant-list";
 
@@ -8,18 +9,25 @@ import { DefaultLayout } from "@/components/layout/default-layout";
 export const ApplicantListPage = () => {
   const { postId } = useParams();
   return (
-    <DefaultLayout
-      scrollbar
-      appbar={
-        <AppBar isBorderExist>
-          <AppBar.AppBarNavigate>
-            <AppBar.BackButton />
-            <AppBar.HeaderText isBigSizeText>참여관리</AppBar.HeaderText>
-          </AppBar.AppBarNavigate>
-        </AppBar>
-      }
-    >
+    <Wrapper>
+      <AppBar isBorderExist>
+        <AppBar.AppBarNavigate>
+          <AppBar.BackButton />
+          <AppBar.HeaderText isBigSizeText>참여관리</AppBar.HeaderText>
+        </AppBar.AppBarNavigate>
+      </AppBar>
       <ApplicantList postId={postId!} />
-    </DefaultLayout>
+    </Wrapper>
   );
 };
+
+const Wrapper = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  max-width: 480px;
+  margin: auto;
+  font-size: 0.88rem;
+  background-color: #ffffff;
+`;

--- a/src/pages/post/applicant-list.tsx
+++ b/src/pages/post/applicant-list.tsx
@@ -57,7 +57,6 @@ export const ApplicantList = ({ postId }: { postId: string }) => {
       });
       setApplyIds(tempApplyIds);
       setOriginApplyIds(tempApplyIds);
-      console.log("OriginApplyIds: ", tempApplyIds);
       const timeoutId = setTimeout(() => {
         setIsDataLoaded(true);
       }, 300);
@@ -79,8 +78,6 @@ export const ApplicantList = ({ postId }: { postId: string }) => {
       });
     }
   };
-
-  console.log("chatroomid: ", chatRoomId);
 
   return (
     <>
@@ -116,7 +113,6 @@ export const ApplicantList = ({ postId }: { postId: string }) => {
                         onSuccess: (res) => {
                           setApplyModal("PostNewMember");
                           setChatMakeRoomId(res);
-                          console.log("makeChat: ", res);
                         },
                         onError: () => {
                           setIsApplyError("APPLY_CHAT_ERROR");

--- a/src/pages/post/applicant-list.tsx
+++ b/src/pages/post/applicant-list.tsx
@@ -80,6 +80,8 @@ export const ApplicantList = ({ postId }: { postId: string }) => {
     }
   };
 
+  console.log("chatroomid: ", chatRoomId);
+
   return (
     <>
       <ApplicantItemList
@@ -105,7 +107,7 @@ export const ApplicantList = ({ postId }: { postId: string }) => {
                     const tempList: string[] = applyIds.map((id) => {
                       return id.userId.toString();
                     });
-                    if (chatRoomId === "") {
+                    if (chatRoomId === "" || chatRoomId === undefined) {
                       const tempData: ChatMakeRequest = {
                         postId: Number(postId),
                         memberIds: tempList,
@@ -122,7 +124,7 @@ export const ApplicantList = ({ postId }: { postId: string }) => {
                       });
                     } else {
                       const tempData = {
-                        chatRoomId: chatRoomId!,
+                        chatRoomId: chatRoomId,
                         addingData: {
                           postId: Number(postId),
                           memberIds: tempList,

--- a/src/pages/posting/posting1.tsx
+++ b/src/pages/posting/posting1.tsx
@@ -24,7 +24,7 @@ export const Posting1 = () => {
 
   return (
     <PageContainer>
-      <PostingAppBar onClick={resetRecoil} nowPage={1} />
+      <PostingAppBar onCustomClick={() => resetRecoil()} nowPage={1} />
       <PostingBoldText>위치를 입력해 주세요</PostingBoldText>
       <InputBox.InputMap
         value={location}

--- a/src/pages/posting/posting2.tsx
+++ b/src/pages/posting/posting2.tsx
@@ -30,7 +30,7 @@ export const Posting2 = () => {
 
   return (
     <PageContainer>
-      <PostingAppBar onClick={() => handleSave()} nowPage={2} />
+      <PostingAppBar onCustomClick={() => handleSave()} nowPage={2} />
       <PostingBoldText style={{ marginBottom: "0.56rem" }}>
         날짜를 선택해주세요
       </PostingBoldText>

--- a/src/pages/posting/posting3.tsx
+++ b/src/pages/posting/posting3.tsx
@@ -57,7 +57,7 @@ export const Posting3 = () => {
 
   return (
     <PageContainer>
-      <PostingAppBar onClick={() => handleSave()} nowPage={3} />
+      <PostingAppBar onCustomClick={() => handleSave()} nowPage={3} />
       <PostingBoldText>
         시작 시간을
         <br />

--- a/src/pages/posting/posting4.tsx
+++ b/src/pages/posting/posting4.tsx
@@ -37,7 +37,7 @@ export const Posting4 = () => {
 
   return (
     <PageContainer>
-      <PostingAppBar onClick={() => handleSave()} nowPage={4} />
+      <PostingAppBar onCustomClick={() => handleSave()} nowPage={4} />
       <PostingBoldText style={{ marginBottom: "1.4rem" }}>
         활동의 소요시간을
         <br />

--- a/src/pages/posting/posting5.tsx
+++ b/src/pages/posting/posting5.tsx
@@ -37,7 +37,7 @@ export const Posting5 = () => {
 
   return (
     <PageContainer>
-      <PostingAppBar onClick={() => handleSave()} nowPage={5} />
+      <PostingAppBar onCustomClick={() => handleSave()} nowPage={5} />
       <PostingBoldText style={{ marginBottom: "1.8rem" }}>
         필요한 인원을
         <br />

--- a/src/pages/posting/posting6.tsx
+++ b/src/pages/posting/posting6.tsx
@@ -26,7 +26,7 @@ export const Posting6 = () => {
 
   return (
     <PageContainer>
-      <PostingAppBar onClick={() => handleSave()} nowPage={6} />
+      <PostingAppBar onCustomClick={() => handleSave()} nowPage={6} />
       <PostingBoldText>활동 제목을 적어보세요</PostingBoldText>
       <PostingInput.InputTitle
         value={title}

--- a/src/pages/posting/posting7.tsx
+++ b/src/pages/posting/posting7.tsx
@@ -41,7 +41,7 @@ export const Posting7 = () => {
   return (
     <PageContainer>
       <PostingAppBar
-        onClick={() => {
+        onCustomClick={() => {
           handleSave();
           navigate(-1);
         }}

--- a/src/pages/posting/posting8.tsx
+++ b/src/pages/posting/posting8.tsx
@@ -18,10 +18,14 @@ export const Posting8 = () => {
       <AppBar>
         <AppBar.AppBarNavigate>
           <AppBar.BackButton
-            onClick={() => {
+            onCustomClick={() => {
               resetRecoil();
               localStorage.removeItem("postId");
+              navigate(`/post/${state.postId}`, {
+                state: { replace: "/post" },
+              });
             }}
+            isBack={false}
           />
         </AppBar.AppBarNavigate>
       </AppBar>

--- a/src/utils/chatdate-to-msgtype.tsx
+++ b/src/utils/chatdate-to-msgtype.tsx
@@ -2,7 +2,7 @@ export const ChatdateToMsgtype = (dateString: string) => {
   const date = new Date(dateString);
   let hours = date.getHours();
   const minutes = date.getMinutes().toString().padStart(2, "0");
-  const seconds = date.getSeconds().toString().padStart(2, "0");
+  // const seconds = date.getSeconds().toString().padStart(2, "0");
   const plot = hours >= 12 ? "오후" : "오전";
   hours = hours % 12 || 12; // 0시를 12시로 표시하기 위해
 

--- a/src/utils/chatdate-to-msgtype.tsx
+++ b/src/utils/chatdate-to-msgtype.tsx
@@ -1,10 +1,11 @@
 export const ChatdateToMsgtype = (dateString: string) => {
   const date = new Date(dateString);
-  let hours = date.getHours();
-  const minutes = date.getMinutes().toString().padStart(2, "0");
-  // const seconds = date.getSeconds().toString().padStart(2, "0");
+  const krDate = new Date(date.getTime() + 9 * 3600000);
+
+  let hours = krDate.getHours();
+  const minutes = krDate.getMinutes().toString().padStart(2, "0");
   const plot = hours >= 12 ? "오후" : "오전";
-  hours = hours % 12 || 12; // 0시를 12시로 표시하기 위해
+  hours = hours % 12 || 12;
 
   return `${plot} ${hours}:${minutes}`;
 };


### PR DESCRIPTION
> ### PR 제목은 핵심 변경 사항을 요약해주세요.

---

## 🙋‍ Summary (요약)

- 참여관리와 마이페이지 도움횟수 필드 추가
- 채팅방 페이지네이션 구현
- 탭을 나갔다 다시 돌아왔을 때 api를 다시 호출하여 생긴 중복 메세지 문제 해결
- 페이지네이션으로 인해 스크롤 할 때 scroll위치 재셋팅

## 🤔 Describe your Change (변경사항)

- 채팅방 페이지네이션 구현 & 페이지네이션으로 인해 스크롤 할 때 scroll위치 재셋팅
  기존에는 roomMsgs는 useChatDataSetting에서 채팅관련 데이터들을 셋팅하고 return값으로 주는 messages를 썼었는데 페이지네이션 구현을 하며 계속 useChatDataSetting호출은 불필요하기에 useGetRoomData에서 페이지네이션쿼리를 계속 호출하는 것으로 수정하였음. 
   채팅리스트의 스크롤이 최상단에 닿으면 다음 페이지를 호출하는데, 이때 스크롤 위치는 top:0으로 고정되기 때문에 카톡처럼 스무스하게 채팅들이 보이고 스크롤을 올리는 시나리오가 구현이 안되었었음. 
``` 
if (chatListRef.current) {
        const firstItem = chatListRef.current.firstChild as HTMLElement | null;
        if (firstItem) {
          const firstItemHeight = firstItem.clientHeight || 0;
          chatListRef.current.scrollTop = firstItemHeight;
        }
      }
```
   이 코드를 추가하고, chatlist컴포넌트에서 chatitem하나하나 분리하여 호출했던것과는 달리 chatItem을 다시 div로 감싸 페이지 단위도 컴포넌트화하여 한 페이지 전체의 height를 알아내어 다음 페이지를 호출해도 스크롤을 최상단으로 계속 안올리고 마지막 chatItem위치에 그대로 있게 했음.

-  탭을 나갔다 다시 돌아왔을 때 api를 다시 호출하여 생긴 중복 메세지 문제 해결
   만약 ws가 연결되어있는 상태로 채팅을 보내고, 브로드캐스트로 받아 화면에 띄울 땐 newRoomMsgs에 저장하여 사용했는데, 이때 탭을 나갔다가 다시 돌아왔을 때 또 다시 roomDataApi를 호출하여 새로 받아온 roomMsgs에는 newRoomMsgs의 내용도 포함되어있어 메세지들이 화면에는 중복으로 보이게 되는 불편사항이 존재하였음. roomData의 재호출로 useEffect를 사용하여 newRoomMsgs를 빈배열로 바꾸면 빈 배열로 바뀌고 스크롤이 최하단으로 내려가는게 설정되어있었는데, 페이지네이션으로 인해 갱신되는 roomData로도 이루어지는 걸로 인한 문제도 발생하였음.
   useState를 이용하여 pagination으로 인한 재호출인지, 탭을 나갔다 와서 생긴 재호출인지의 여부를 가지고 탭을 나갔다 와서 생긴 재 호출이면 newRoomMsgs를 빈배열로 다시 저장하게 함.

## 🔗 Issue number and link (참고)

-
