### PR TITLE
특정 브라우저 환경을 지원하지 않는 Firebase SDK에 대해 조건 검사 및 예외 처리

### DIFF
--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,7 +1,7 @@
 // Import the functions you need from the SDKs you need
 import { initializeApp } from "firebase/app";
 import { getAuth } from "firebase/auth";
-import { getMessaging } from "firebase/messaging/sw";
+import { getMessaging, Messaging } from "firebase/messaging/sw";
 
 const firebaseConfig = {
   apiKey: process.env.REACT_APP_FIREBASE_API_KEY,
@@ -15,6 +15,11 @@ const firebaseConfig = {
 
 const app = initializeApp(firebaseConfig);
 const auth = getAuth(app);
-const messaging = getMessaging(app);
+
+let messaging: Messaging | undefined;
+
+if (typeof window !== "undefined" && typeof window.navigator !== "undefined") {
+  messaging = getMessaging(app);
+}
 
 export { app, auth, messaging };

--- a/src/lib/messaging.ts
+++ b/src/lib/messaging.ts
@@ -16,7 +16,13 @@ async function requestPermission(): Promise<PermissionType> {
   });
 }
 
-async function requestToken(): Promise<string> {
+async function requestToken(): Promise<string | null> {
+  if (!messaging) {
+    alert("이 브라우저는 알림을 지원하지 않습니다.");
+    devLog("알람 지원X. 현재 브라우저 정보: ", navigator.userAgent);
+    return null;
+  }
+
   const token = await getToken(messaging, {
     vapidKey: process.env.REACT_APP_FIREBASE_MEASUREMENT_ID,
   })
@@ -32,6 +38,7 @@ async function requestToken(): Promise<string> {
       alert("권한이 허가되어있지 않아 알림을 보낼 수 없습니다");
       devLog("토큰을 받는 과정에서 에러가 발생하였습니다 ", err);
       // ...
+      return null;
     });
   return token as string;
 }

--- a/src/pages/post/post-list.tsx
+++ b/src/pages/post/post-list.tsx
@@ -47,8 +47,10 @@ export const PostList = () => {
       const permission = await requestPermission();
       if (permission === "granted") {
         const token = await requestToken();
-        setFcmToken(token);
-        mutate(token);
+        if(token != null){
+          setFcmToken(token);
+          mutate(token);
+        }
       }
     };
 


### PR DESCRIPTION
issue #77 
This browser doesn't support the API's required to use the Firebase SDK. (messaging/unsupported-browser) 에러 발생.

FireBase SDK 버전을 낮추는 대신 window.navigator 여부를 체크하도록 추가 구현.
