### PR TITLE
85 0821 피드백 (2)

### DIFF
--- a/src/components/common/activity-box.tsx
+++ b/src/components/common/activity-box.tsx
@@ -191,7 +191,7 @@ const MoreInfoContainer = styled.div`
   flex-direction: column;
   gap: 20px;
   width: 100%;
-  padding: 24px 22px 45px;
+  padding: 24px 22px 100px;
 `;
 
 const PromiseInfoList = styled.div`

--- a/src/components/common/bottom-fixed.tsx
+++ b/src/components/common/bottom-fixed.tsx
@@ -73,7 +73,7 @@ BottomFixed.Button = Button;
 const BottomFixedContainer = styled.div<{ $alignDirection: string }>`
   display: flex;
   position: fixed;
-  margin: 0 2rem;
+  padding: 0 2rem;
   flex-direction: ${({ $alignDirection }) => $alignDirection};
   gap: 11px;
   left: 0;

--- a/src/components/common/bottom-fixed.tsx
+++ b/src/components/common/bottom-fixed.tsx
@@ -54,12 +54,19 @@ export const BottomFixed = ({
     <BottomFixedContainer
       $alignDirection={alignDirection}
       style={{
-        bottom: `calc(${
+        paddingBottom: `calc(${
           currentUrl[1] == "post" ||
           (currentUrl[1] == "chat" && !currentUrl[2]) ||
           currentUrl[1] == "mypage"
             ? "4rem"
             : "2.2rem"
+        } + ${!resizeHeight ? 0 : resizeHeight - 20}px)`,
+        paddingTop: `calc(${
+          currentUrl[1] == "post" ||
+          (currentUrl[1] == "chat" && !currentUrl[2]) ||
+          currentUrl[1] == "mypage"
+            ? "0.5rem" // 네비바(3.5rem)와 BottomFixedContainer(4rem)사이의 간격 만큼 TOP 을 추가함
+            : "0rem"
         } + ${!resizeHeight ? 0 : resizeHeight - 20}px)`,
       }}
     >
@@ -78,6 +85,7 @@ const BottomFixedContainer = styled.div<{ $alignDirection: string }>`
   gap: 11px;
   left: 0;
   right: 0;
+  bottom: 0;
   background-color: white;
 `;
 

--- a/src/pages/post/post-detail.tsx
+++ b/src/pages/post/post-detail.tsx
@@ -258,7 +258,7 @@ export const PostDetailPage = () => {
               </BottomFixed.Button>
             ) : (
               <BottomFixed.Button
-                rounded={false}
+                style={{ backgroundColor: "#e4e8f1", color: "#eb5242" }}
                 onClick={() => {
                   setApplyModal(true);
                 }}

--- a/src/pages/post/post-detail.tsx
+++ b/src/pages/post/post-detail.tsx
@@ -183,7 +183,7 @@ export const PostDetailPage = () => {
           {data?.userCurrentStatus.writer ? (
             data?.marketPostResponse.status === "RECRUITING" ? (
               <>
-                <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                <RowContainer>
                   <BottomFixed.Button 
                       style={{ backgroundColor: "#e4e8f1", color: "#253659" }}
                       onClick={() => {
@@ -202,7 +202,7 @@ export const PostDetailPage = () => {
                   >
                     삭제하기
                   </BottomFixed.Button>
-                </div>
+                </RowContainer>
                 <BottomFixed.Button onClick={() => setRepostModal(true)}>
                   끌어올리기
                 </BottomFixed.Button>
@@ -396,6 +396,14 @@ export const PostDetailPage = () => {
     </DefaultLayout>
   );
 };
+
+const RowContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  width: 100%; /* 컨테이너의 너비에 맞춤 */
+  max-width: calc(480px - 3.2rem); /* 최대 너비를 설정하여 초과 방지 */
+  margin: auto;
+`;
 
 const PaddingWrapper = styled.div<{ $isWriter: boolean }>`
   position: relative;


### PR DESCRIPTION
## 수정

### 1. 게시글 수정/삭제 버튼 스타일 수정
모바일 상에선 문제가 없으나 
웹상에서는 버튼이 Container 의 범위를 넘어서는 문제를 해결
<img width="1186" alt="image" src="https://github.com/user-attachments/assets/e10ebe7f-4e9b-499c-922f-d6719f3c9a6d">
<img width="892" alt="image" src="https://github.com/user-attachments/assets/f9fef1e9-89d7-40bf-89e1-1dbb1ef6fd1f">
<br><br>


### 2. BottomFixedContainer 뒤의 배경 콘텐츠가 노출되지 않도록 수정
게시글 내용이 길어질 경우, 기존 BottomFixedContainer 는 margin 으로 설정되어있어 배경 컨텐츠가 노출되었다.
<img width="329" alt="스크린샷 2024-08-23 오전 9 46 48" src="https://github.com/user-attachments/assets/ae6fad40-2f80-401c-9e98-110ce525f6ce">
<br>
추가로, 게시글 내용이 길어질 경우, BottomFixedContainer로 인해 본문 아래 내용이 잘리는 현상을 수정<br><br>

<img width="325" alt="스크린샷 2024-08-23 오전 9 50 28" src="https://github.com/user-attachments/assets/c7eeaaf3-ec8f-4c04-99b6-4882af587f22">
<img width="325" alt="스크린샷 2024-08-23 오전 9 50 42" src="https://github.com/user-attachments/assets/1bb429b5-09ec-41a4-92ee-a1c0a14324a2">
<br><br>

### 3. 신청 취소하기 버튼을 빨간 글자로 강조, UX 일관화(rounded=true)

<img width="330" alt="image" src="https://github.com/user-attachments/assets/36d9bd46-1dfd-484b-94da-82f2f14cd8be">
<img width="324" alt="image" src="https://github.com/user-attachments/assets/300b5eb6-4f80-4027-ab91-9f420ad277c5">
